### PR TITLE
Replaced maxcdn.com with cloudflare.com

### DIFF
--- a/src/TwemojiText/index.tsx
+++ b/src/TwemojiText/index.tsx
@@ -36,7 +36,7 @@ const TwemojiText: React.VFC<TextProps & TwemojiTextProps> = ({
                 height: textStyle?.fontSize ?? 14
             }}
             source={{
-                uri: `https://twemoji.maxcdn.com/2/72x72/${emojiUnicode(
+                uri: `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/${emojiUnicode(
                     emoji
                 )}.png`,
             }}


### PR DESCRIPTION
Currently the emoji's dont render when using the npm package, this is because maxcdn.com is not supported anymore. I replaced the domain with cloudflare and the package works again. 